### PR TITLE
fix: use common js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "vite-plugin-shadow-style",
   "version": "1.0.3",
-  "type": "module",
   "description": "A vite plugin to inject css into web components' shadow dom",
   "author": "Andrea Cappuccio <hood@null.net>",
   "license": "ISC",
@@ -18,6 +17,7 @@
     "shadow-dom"
   ],
   "main": "dist/plugin.js",
+  "types": "dist/plugin.d.ts",
   "files": [
     "src",
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "CommonJS",
     "moduleResolution": "Node",
+    "declaration": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Related to: https://github.com/hood/vite-plugin-shadow-style/issues/1

These changes make the switch to CommonJS complete. 