### PR TITLE
escape backticks in sources before injecting template string

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -55,10 +55,12 @@ export function shadowStyle(
           outputBundle as OutputBundle
         );
 
+        const escapedStyles = injectionCandidate.source.replace(/`/g, "\\`");
+
         // Swap the style placeholder with the style to inject.
         injectionTarget.code = injectionTarget.code.replace(
           "SHADOW_STYLE",
-          `\`${injectionCandidate.source}\``
+          `\`${escapedStyles}\``
         );
 
         if (pluginConfig.iife)


### PR DESCRIPTION
We've had an issue where the css from the `@tailwindcss/typography` package contains a couple of backticks, which resulted in a broken build because the `SHADOW_STYLE` was incorrectly split into multiple template strings.