### PR TITLE
feat: add output filter method to plugin config

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,10 +15,15 @@ type PluginConfig = {
    * causing conflicts.
    */
   iife?: boolean;
+  /**
+   * Filter the output css content. This can be required as it is possible that packages
+   * which generate css include extra characters or metadata that is not desired.
+   */
+  filterOutput?: (out: string) => string
 };
 
 export function shadowStyle(
-  pluginConfig: PluginConfig = { iife: false }
+  pluginConfig: PluginConfig = { iife: false, filterOutput: (out) => out }
 ): Plugin {
   return {
     name: PLUGIN_NAME,
@@ -58,7 +63,7 @@ export function shadowStyle(
         // Swap the style placeholder with the style to inject.
         injectionTarget.code = injectionTarget.code.replace(
           "SHADOW_STYLE",
-          `\`${injectionCandidate.source}\``
+          `\`${pluginConfig.filterOutput?.(injectionCandidate.source as string)}\``
         );
 
         if (pluginConfig.iife)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -16,14 +16,14 @@ type PluginConfig = {
    */
   iife?: boolean;
   /**
-   * Filter the output css content. This can be required as it is possible that packages
+   * Transform the output css content. This can be required as it is possible that packages
    * which generate css include extra characters or metadata that is not desired.
    */
-  filterOutput?: (out: string) => string
+  transformOutput?: (out: string) => string
 };
 
 export function shadowStyle(
-  pluginConfig: PluginConfig = { iife: false, filterOutput: (out) => out }
+  pluginConfig: PluginConfig = { iife: false, transformOutput: (out) => out }
 ): Plugin {
   return {
     name: PLUGIN_NAME,
@@ -65,7 +65,7 @@ export function shadowStyle(
         // Swap the style placeholder with the style to inject.
         injectionTarget.code = injectionTarget.code.replace(
           "SHADOW_STYLE",
-          `\`${pluginConfig.filterOutput?.(escapedStyles as string)}\``
+          `\`${pluginConfig.transformOutput(escapedStyles as string)}\``
         );
 
         if (pluginConfig.iife)


### PR DESCRIPTION
I'm using UnoCSS for my custom element. The source in the build step includes some metadata which is probably removed later in the build chain but breaks the output for this plugin. Therefore I propose the possibility to filter the output before it is placed into the code.

Usage looks like this:

```js
shadowStyle({
    filterOutput: (o) => o.replace(/^[^@]*/, '')
})